### PR TITLE
Rename example resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ module "wif" {
 
 ```
 
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -81,8 +82,9 @@ module "wif" {
 
 | Name | Type |
 |------|------|
-| [google_iam_workload_identity_pool.example](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
-| [google_iam_workload_identity_pool_provider.example](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_iam_workload_identity_pool.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool_provider.provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_project_iam_member.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 
@@ -95,7 +97,7 @@ module "wif" {
 | <a name="input_pool_display_name"></a> [pool\_display\_name](#input\_pool\_display\_name) | n/a | `string` | `null` | no |
 | <a name="input_pool_id"></a> [pool\_id](#input\_pool\_id) | n/a | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
-| <a name="input_service_accounts"></a> [service\_accounts](#input\_service\_accounts) | n/a | <pre>list(object({<br>    name           = string<br>    attribute      = string<br>    all_identities = bool<br>    roles = list(string)<br>  }))</pre> | n/a | yes |
+| <a name="input_service_accounts"></a> [service\_accounts](#input\_service\_accounts) | n/a | <pre>list(object({<br>    name           = string<br>    attribute      = string<br>    all_identities = bool<br>    roles          = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_wif_providers"></a> [wif\_providers](#input\_wif\_providers) | n/a | `list(any)` | n/a | yes |
 
 ## Outputs
@@ -107,3 +109,4 @@ module "wif" {
 | <a name="output_pool_state"></a> [pool\_state](#output\_pool\_state) | Pool state |
 | <a name="output_provider_id"></a> [provider\_id](#output\_provider\_id) | Provider id |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service Account name |
+<!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-resource "google_iam_workload_identity_pool" "example" {
+resource "google_iam_workload_identity_pool" "primary" {
   workload_identity_pool_id = var.pool_id
   project                   = var.project_id
   display_name              = var.pool_display_name
@@ -6,9 +6,9 @@ resource "google_iam_workload_identity_pool" "example" {
   disabled                  = var.pool_disabled
 }
 
-resource "google_iam_workload_identity_pool_provider" "example" {
+resource "google_iam_workload_identity_pool_provider" "provider" {
   for_each                           = { for i in var.wif_providers : i.provider_id => i }
-  workload_identity_pool_id          = google_iam_workload_identity_pool.example.workload_identity_pool_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.primary.workload_identity_pool_id
   workload_identity_pool_provider_id = each.value.provider_id
   project                            = var.project_id
   display_name                       = lookup(each.value, "display_name", null)
@@ -45,7 +45,7 @@ resource "google_service_account_iam_member" "member" {
   for_each = { for account in var.service_accounts : account.name => account }
 
   service_account_id = google_service_account.service_account[each.value.name].name
-  member             = "${each.value.all_identities == false ? "principal" : "principalSet"}://iam.googleapis.com/${google_iam_workload_identity_pool.example.name}/${each.value.attribute}"
+  member             = "${each.value.all_identities == false ? "principal" : "principalSet"}://iam.googleapis.com/${google_iam_workload_identity_pool.primary.name}/${each.value.attribute}"
   role               = "roles/iam.workloadIdentityUser"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,23 +1,23 @@
 output "pool_id" {
   description = "Pool id"
-  value       = google_iam_workload_identity_pool.example.id
+  value       = google_iam_workload_identity_pool.primary.id
 }
 
 output "pool_state" {
   description = "Pool state"
-  value       = google_iam_workload_identity_pool.example.state
+  value       = google_iam_workload_identity_pool.primary.state
 }
 
 output "pool_name" {
   description = "Pool name"
-  value       = google_iam_workload_identity_pool.example.name
+  value       = google_iam_workload_identity_pool.primary.name
 }
 
 output "provider_id" {
   description = "Provider id"
-  value = { for id in var.wif_providers : id.provider_id => { id = google_iam_workload_identity_pool_provider.example[id.provider_id].id
-    state = google_iam_workload_identity_pool_provider.example[id.provider_id].state
-    name = google_iam_workload_identity_pool_provider.example[id.provider_id].name }
+  value = { for id in var.wif_providers : id.provider_id => { id = google_iam_workload_identity_pool_provider.provider[id.provider_id].id
+    state = google_iam_workload_identity_pool_provider.provider[id.provider_id].state
+    name = google_iam_workload_identity_pool_provider.provider[id.provider_id].name }
   }
 }
 


### PR DESCRIPTION
First of all thanks for the module, good to get something multi platform for GCP WLIF.

This PR doesn't change function of the module, it only replaces the `example` resource names to (IMO) more appropriate representations (the naming style being equivalent of what is used in [terraform-google-kubernetes-engine](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/cluster.tf)). 

This is a breaking change, terraform will want to recreate already existing resources which might not be desirable. This can be fixed by renaming existing resource `terraform state mv <source_address> <destination_address>`, but I understand if you'd prefer to keep the module with original resource names.
